### PR TITLE
inventory: explicitly mark transactions as lazy-loaded

### DIFF
--- a/backend/src/main/java/com/borsibaar/entity/Inventory.java
+++ b/backend/src/main/java/com/borsibaar/entity/Inventory.java
@@ -49,7 +49,7 @@ public class Inventory {
     private Product product;
 
     @OneToMany(mappedBy = "inventory", fetch = FetchType.LAZY)
-    private Set<InventoryTransaction> transactions = new HashSet<>();
+    private final Set<InventoryTransaction> transactions = new HashSet<>();
 
     // Custom constructor for easy creation
     public Inventory(Long organizationId, Product product, BigDecimal quantity, BigDecimal adjustedPrice) {


### PR DESCRIPTION
Lazy-loading was already in effect, this change makes it visible in code aswell.
created_at should never change after insert.
Prevents accidental reassignment (transactions = new HashSet<>()).