### PR TITLE
 #51 New category items do not show on Client page 

### DIFF
--- a/frontend/app/(protected)/client/page.tsx
+++ b/frontend/app/(protected)/client/page.tsx
@@ -124,7 +124,7 @@ export default function ClientProductsByCategory() {
             </h2>
           </div>
 
-          <div className="columns-1 min-[1800px]:!columns-2 gap-4 min-[1800px]:max-h-[90vh]" style={{ "columnFill": "auto" }}>
+          <div className="columns-1 min-[1800px]:!columns-2 gap-4">
             {loading && !totalItems && (
               <div className="col-span-full flex h-40 items-center justify-center text-lg text-[#a7a3c7]">
                 Loading…


### PR DESCRIPTION
remove max height and columnFill - some categories were hidden on desktop view because of max height and columnfill